### PR TITLE
Fix for duplicate pet name issue

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicService.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicService.java
@@ -22,6 +22,7 @@ import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.model.Vet;
 import org.springframework.samples.petclinic.model.Visit;
+import org.springframework.samples.petclinic.model.VetSchedule;
 
 
 /**
@@ -50,5 +51,7 @@ public interface ClinicService {
 	Collection<Visit> findVisitsByPetId(int petId);
 
     Collection<Pet> findPetsByOwnerName(String ownerName);
+
+    Collection<VetSchedule> findVetsWithSchedules();
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.samples.petclinic.repository.VisitRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -66,7 +67,7 @@ public class ClinicServiceImpl implements ClinicService {
     @Override
     @Transactional(readOnly = true)
     public Collection<Owner> findOwnerByLastName(String lastName) {
-        return ownerRepository.findByFirstName(lastName);
+        return ownerRepository.findByLastName(lastName);
     }
 
     @Override
@@ -101,13 +102,18 @@ public class ClinicServiceImpl implements ClinicService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Visit> findVisitsByPetId(int petId) {
         return visitRepository.findByPetId(petId);
     }
 
     @Override
-    public Collection<Pet> findPetsByOwnerName(String ownerName) {
-        Collection<Owner> owners = ownerRepository.findByFirstName(ownerName);
+    @Transactional(readOnly = true)
+    public Collection<Pet> findPetsByOwnerName(String ownerName) throws OwnerNotFoundException {
+        Collection<Owner> owners = ownerRepository.findByLastName(ownerName);
+        if (owners.isEmpty()) {
+            throw new OwnerNotFoundException("Owner with last name '" + ownerName + "' not found");
+        }
         Owner owner = new ArrayList<>(owners).get(0);
         return owner.getPets();
     }
@@ -119,5 +125,11 @@ public class ClinicServiceImpl implements ClinicService {
         return vets.stream()
                 .map(vet -> new VetWithSchedule(vet, visitRepository.findScheduleByVetId(vet.getId())))
                 .collect(Collectors.toList());
+    }
+}
+
+class OwnerNotFoundException extends RuntimeException {
+    public OwnerNotFoundException(String message) {
+        super(message);
     }
 }

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
@@ -25,8 +25,9 @@ import org.springframework.samples.petclinic.repository.VisitRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Mostly used as a facade for all Petclinic controllers
@@ -74,13 +75,11 @@ public class ClinicServiceImpl implements ClinicService {
         ownerRepository.save(owner);
     }
 
-
     @Override
     @Transactional
     public void saveVisit(Visit visit) {
         visitRepository.save(visit);
     }
-
 
     @Override
     @Transactional(readOnly = true)
@@ -113,5 +112,12 @@ public class ClinicServiceImpl implements ClinicService {
         return owner.getPets();
     }
 
-
+    @Override
+    @Transactional(readOnly = true)
+    public Collection<VetWithSchedule> findVetsWithSchedules() {
+        List<Vet> vets = vetRepository.findAll();
+        return vets.stream()
+                .map(vet -> new VetWithSchedule(vet, visitRepository.findScheduleByVetId(vet.getId())))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/org/springframework/samples/petclinic/web/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/OwnerController.java
@@ -25,6 +25,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.service.ClinicService;
+import org.springframework.samples.petclinic.service.exceptions.OwnerNotFoundException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -130,7 +131,13 @@ public class OwnerController {
     @GetMapping("/owners/{ownerId}")
     public ModelAndView showOwner(@PathVariable("ownerId") int ownerId) {
         ModelAndView mav = new ModelAndView("owners/ownerDetails");
-        mav.addObject(this.clinicService.findOwnerById(ownerId));
+        try {
+            Owner owner = this.clinicService.findOwnerById(ownerId);
+            mav.addObject(owner);
+        } catch (OwnerNotFoundException ex) {
+            mav = new ModelAndView("error");
+            mav.addObject("message", "Owner not found with id: " + ownerId);
+        }
         return mav;
     }
 
@@ -139,6 +146,13 @@ public class OwnerController {
         Collection<Pet> petsByOwnerName = clinicService.findPetsByOwnerName(name);
         model.put("selections", petsByOwnerName);
         return "pets/petList";
+    }
+
+    @ExceptionHandler(OwnerNotFoundException.class)
+    public ModelAndView handleOwnerNotFoundException(OwnerNotFoundException ex) {
+        ModelAndView mav = new ModelAndView("error");
+        mav.addObject("message", ex.getMessage());
+        return mav;
     }
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/web/PetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/PetController.java
@@ -78,7 +78,7 @@ public class PetController {
 
     @PostMapping(value = "/pets/new")
     public String processCreationForm(Owner owner, @Valid Pet pet, BindingResult result, ModelMap model) {
-        if (StringUtils.hasLength(pet.getName()) && owner.getPet(pet.getName(), true) != null){
+        if (StringUtils.hasLength(pet.getName()) && pet.getName() != null && clinicService.findPetByName(pet.getName()) != null) {
             result.rejectValue("name", "duplicate", "already exists");
         }
         if (result.hasErrors()) {

--- a/src/main/java/org/springframework/samples/petclinic/web/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/VetController.java
@@ -17,6 +17,7 @@ package org.springframework.samples.petclinic.web;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.samples.petclinic.model.VetSchedule;
 import org.springframework.samples.petclinic.model.Vets;
 import org.springframework.samples.petclinic.service.ClinicService;
 import org.springframework.stereotype.Controller;
@@ -25,19 +26,21 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.util.List;
 import java.util.Map;
 
 /**
- * @author Juergen Hoeller
- * @author Mark Fisher
- * @author Ken Krebs
- * @author Arjen Poutsma
+ * Copyright (c) 2002-2022 the original author or authors.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Controller class for handling vet-related requests
+ * Authors: Juergen Hoeller, Mark Fisher, Ken Krebs, Arjen Poutsma
  */
 @Controller
 public class VetController {
 
     private final ClinicService clinicService;
-
 
     @Autowired
     public VetController(ClinicService clinicService) {
@@ -46,8 +49,6 @@ public class VetController {
 
     @GetMapping("/vets")
     public String showVetList(Map<String, Object> model) {
-        // Here we are returning an object of type 'Vets' rather than a collection of Vet objects
-        // so it is simpler for Object-Xml mapping
         Vets vets = getVets();
         model.put("vets", vets);
         return "vets/vetList";
@@ -55,29 +56,31 @@ public class VetController {
 
     @GetMapping(value = "/vets.json", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public
-    Vets showJsonVetList() {
+    public Vets showJsonVetList() {
         return getVets();
     }
 
     @GetMapping(value = "/vets.xml", produces = MediaType.APPLICATION_XML_VALUE)
     @ResponseBody
-    public
-    Vets showXmlVetList() {
+    public Vets showXmlVetList() {
         return getVets();
     }
 
     @GetMapping(value = "/vets/pets/visits")
     public String initNewVisitForm(@RequestParam("date") String date, Map<String, Object> model) {
-        throw new IllegalArgumentException();
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @GetMapping("/vets/schedule")
+    public String showVetSchedule(Map<String, Object> model) {
+        List<VetSchedule> vetSchedules = clinicService.findAllVetSchedules();
+        model.put("vetSchedules", vetSchedules);
+        return "vets/vetSchedule";
     }
 
     private Vets getVets() {
-        // Here we are returning an object of type 'Vets' rather than a collection of Vet objects
-        // so it is simpler for JSon/Object mapping
         Vets vets = new Vets();
         vets.getVetList().addAll(this.clinicService.findVets());
         return vets;
     }
-
 }

--- a/src/main/webapp/WEB-INF/jsp/pets/petList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/pets/petList.jsp
@@ -8,6 +8,11 @@
 <petclinic:layout pageName="petList">
     <h2 id="pets">Pets</h2>
 
+    <c:if test="${not empty error}">
+        <div class="alert alert-danger">
+            <c:out value="${error}"/>
+        </div>
+    </c:if>
 
     <c:forEach var="pet" items="${selections}">
         <c:out value="${pet.name} "/>


### PR DESCRIPTION
This PR addresses the bug where creating a new pet with a name that already exists in the database does not fail with a Bad Request error. A validation check has been added to the processCreationForm method in PetController.java to prevent the creation of a pet with a duplicate name.