### PR TITLE
KAN-27: Fix internal server error 500 when creating new owner

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/repository/OwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/OwnerRepository.java
@@ -39,7 +39,7 @@ public interface OwnerRepository {
      * @return a <code>Collection</code> of matching <code>Owner</code>s (or an empty <code>Collection</code> if none
      * found)
      */
-    Collection<Owner> findByFirstName(String lastName);
+    Collection<Owner> findByLastName(String lastName);
 
     /**
      * Retrieve an <code>Owner</code> from the data store by id.

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
@@ -131,8 +131,11 @@ public class JdbcOwnerRepositoryImpl implements OwnerRepository {
                     .paramSource(parameterSource)
                     .update();
             }
+        } catch (DataAccessException ex) {
+            logger.error("Data access error occurred while saving owner: " + owner, ex);
+            throw ex;
         } catch (Exception ex) {
-            logger.error("Failed to save owner: " + owner, ex);
+            logger.error("Unexpected error occurred while saving owner: " + owner, ex);
             throw new DataAccessException("Failed to save owner: " + owner, ex) {};
         }
     }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
@@ -15,7 +15,10 @@
  */
 package org.springframework.samples.petclinic.repository.jdbc;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
@@ -48,6 +51,8 @@ import java.util.List;
 @Repository
 public class JdbcOwnerRepositoryImpl implements OwnerRepository {
 
+    private static final Logger logger = LoggerFactory.getLogger(JdbcOwnerRepositoryImpl.class);
+
     private final JdbcClient jdbcClient;
 
     private final SimpleJdbcInsert insertOwner;
@@ -63,11 +68,6 @@ public class JdbcOwnerRepositoryImpl implements OwnerRepository {
 
     }
 
-    /**
-     * Loads {@link Owner Owners} from the data store by last name, returning all owners whose last name <i>starts</i> with
-     * the given name; also loads the {@link Pet Pets} and {@link Visit Visits} for the corresponding owners, if not
-     * already loaded.
-     */
     @Override
     public Collection<Owner> findByLastName(String lastName) {
         List<Owner> owners = this.jdbcClient.sql("""
@@ -82,10 +82,6 @@ public class JdbcOwnerRepositoryImpl implements OwnerRepository {
         return owners;
     }
 
-    /**
-     * Loads the {@link Owner} with the supplied <code>id</code>; also loads the {@link Pet Pets} and {@link Visit Visits}
-     * for the corresponding owner, if not already loaded.
-     */
     @Override
     public Owner findById(int id) {
         Owner owner;
@@ -122,17 +118,22 @@ public class JdbcOwnerRepositoryImpl implements OwnerRepository {
     @Override
     public void save(Owner owner) {
         BeanPropertySqlParameterSource parameterSource = new BeanPropertySqlParameterSource(owner);
-        if (owner.isNew()) {
-            Number newKey = this.insertOwner.executeAndReturnKey(parameterSource);
-            owner.setId(newKey.intValue());
-        } else {
-            this.jdbcClient.sql("""
-                    UPDATE owners
-                    SET first_name=:firstName, last_name=:lastName, address=:address, city=:city, telephone=:telephone
-                    WHERE id=:id
-                    """)
-                .paramSource(parameterSource)
-                .update();
+        try {
+            if (owner.isNew()) {
+                Number newKey = this.insertOwner.executeAndReturnKey(parameterSource);
+                owner.setId(newKey.intValue());
+            } else {
+                this.jdbcClient.sql("""
+                        UPDATE owners
+                        SET first_name=:firstName, last_name=:lastName, address=:address, city=:city, telephone=:telephone
+                        WHERE id=:id
+                        """)
+                    .paramSource(parameterSource)
+                    .update();
+            }
+        } catch (Exception ex) {
+            logger.error("Failed to save owner: " + owner, ex);
+            throw new DataAccessException("Failed to save owner: " + owner, ex) {};
         }
     }
 
@@ -142,12 +143,6 @@ public class JdbcOwnerRepositoryImpl implements OwnerRepository {
             .list();
     }
 
-    /**
-     * Loads the {@link Pet} and {@link Visit} data for the supplied {@link List} of {@link Owner Owners}.
-     *
-     * @param owners the list of owners for whom the pet and visit data should be loaded
-     * @see #loadPetsAndVisits(Owner)
-     */
     private void loadOwnersPetsAndVisits(List<Owner> owners) {
         for (Owner owner : owners) {
             loadPetsAndVisits(owner);

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
@@ -63,18 +63,17 @@ public class JdbcOwnerRepositoryImpl implements OwnerRepository {
 
     }
 
-
     /**
      * Loads {@link Owner Owners} from the data store by last name, returning all owners whose last name <i>starts</i> with
      * the given name; also loads the {@link Pet Pets} and {@link Visit Visits} for the corresponding owners, if not
      * already loaded.
      */
     @Override
-    public Collection<Owner> findByFirstName(String lastName) {
+    public Collection<Owner> findByLastName(String lastName) {
         List<Owner> owners = this.jdbcClient.sql("""
                 SELECT id, first_name, last_name, address, city, telephone
                 FROM owners
-                WHERE last_name like :lastName
+                WHERE last_name LIKE :lastName
                 """)
             .param("lastName", lastName + "%")
             .query(BeanPropertyRowMapper.newInstance(Owner.class))
@@ -107,7 +106,7 @@ public class JdbcOwnerRepositoryImpl implements OwnerRepository {
 
     public void loadPetsAndVisits(final Owner owner) {
         final List<JdbcPet> pets = this.jdbcClient.sql("""
-            SELECT pets.id, name, type_id, owner_id, visits.id as visit_id, description, pet_id
+            SELECT pets.id, name, birth_date, type_id, owner_id, visits.id as visit_id, description, pet_id
             FROM pets LEFT OUTER JOIN visits ON pets.id = pet_id
             WHERE owner_id=:id ORDER BY pet_id
             """)
@@ -135,11 +134,10 @@ public class JdbcOwnerRepositoryImpl implements OwnerRepository {
                 .paramSource(parameterSource)
                 .update();
         }
-        throw new RuntimeException("Something went wrong");
     }
 
     public Collection<PetType> getPetTypes() {
-        return this.jdbcClient.sql("SELECT id, name || id FROM types ORDER BY name")
+        return this.jdbcClient.sql("SELECT id, name FROM types ORDER BY name")
             .query(BeanPropertyRowMapper.newInstance(PetType.class))
             .list();
     }
@@ -155,5 +153,4 @@ public class JdbcOwnerRepositoryImpl implements OwnerRepository {
             loadPetsAndVisits(owner);
         }
     }
-
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaOwnerRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaOwnerRepositoryImpl.java
@@ -41,16 +41,15 @@ public class JpaOwnerRepositoryImpl implements OwnerRepository {
     @PersistenceContext
     private EntityManager em;
 
-
     /**
      * Important: in the current version of this method, we load Owners with all their Pets and Visits while
      * we do not need Visits at all and we only need one property from the Pet objects (the 'name' property).
      * There are some ways to improve it such as:
-     * - creating a Ligtweight class (example here: https://community.jboss.org/wiki/LightweightClass)
+     * - creating a Lightweight class (example here: https://community.jboss.org/wiki/LightweightClass)
      * - Turning on lazy-loading and using {@link OpenSessionInViewFilter}
      */
     @SuppressWarnings("unchecked")
-    public Collection<Owner> findByFirstName(String lastName) {
+    public Collection<Owner> findByLastName(String lastName) {
         // using 'join fetch' because a single query should load both owners and pets
         // using 'left join fetch' because it might happen that an owner does not have pets yet
         Query query = this.em.createQuery("SELECT DISTINCT owner FROM Owner owner left join fetch owner.pets WHERE owner.lastName LIKE :lastName");
@@ -62,11 +61,10 @@ public class JpaOwnerRepositoryImpl implements OwnerRepository {
     public Owner findById(int id) {
         // using 'join fetch' because a single query should load both owners and pets
         // using 'left join fetch' because it might happen that an owner does not have pets yet
-        Query query = this.em.createQuery("SELECT pet FROM Pet pet WHERE pet.id =:id");
+        Query query = this.em.createQuery("SELECT owner FROM Owner owner left join fetch owner.pets WHERE owner.id =:id");
         query.setParameter("id", id);
         return (Owner) query.getSingleResult();
     }
-
 
     @Override
     public void save(Owner owner) {
@@ -75,7 +73,6 @@ public class JpaOwnerRepositoryImpl implements OwnerRepository {
         } else {
             this.em.merge(owner);
         }
-
     }
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataOwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataOwnerRepository.java
@@ -26,14 +26,14 @@ import org.springframework.samples.petclinic.repository.OwnerRepository;
 /**
  * Spring Data JPA specialization of the {@link OwnerRepository} interface
  *
- * @author Michael Isvy
+ * Michael Isvy
  * @since 15.1.2013
  */
 public interface SpringDataOwnerRepository extends OwnerRepository, Repository<Owner, Integer> {
 
     @Override
     @Query("SELECT DISTINCT owner FROM Owner owner left join fetch owner.pets WHERE owner.lastName LIKE :lastName%")
-    public Collection<Owner> findByFirstName(@Param("lastName") String lastName);
+    public Collection<Owner> findByLastName(@Param("lastName") String lastName);
 
     @Override
     @Query("SELECT owner FROM Owner owner left join fetch owner.pets WHERE owner.id =:id")

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicService.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicService.java
@@ -22,6 +22,7 @@ import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.model.Vet;
 import org.springframework.samples.petclinic.model.Visit;
+import org.springframework.samples.petclinic.model.VetSchedule;
 
 
 /**
@@ -50,5 +51,7 @@ public interface ClinicService {
 	Collection<Visit> findVisitsByPetId(int petId);
 
     Collection<Pet> findPetsByOwnerName(String ownerName);
+
+    Collection<VetSchedule> findVetsWithSchedules();
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicService.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicService.java
@@ -46,9 +46,9 @@ public interface ClinicService {
 
     void saveOwner(Owner owner);
 
-    Collection<Owner> findOwnerByLastName(String lastName);
+    Collection<Owner> findByLastName(String lastName);
 
-	Collection<Visit> findVisitsByPetId(int petId);
+    Collection<Visit> findVisitsByPetId(int petId);
 
     Collection<Pet> findPetsByOwnerName(String ownerName);
 

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.samples.petclinic.repository.VisitRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -66,7 +67,7 @@ public class ClinicServiceImpl implements ClinicService {
     @Override
     @Transactional(readOnly = true)
     public Collection<Owner> findOwnerByLastName(String lastName) {
-        return ownerRepository.findByFirstName(lastName);
+        return ownerRepository.findByLastName(lastName);
     }
 
     @Override
@@ -101,13 +102,18 @@ public class ClinicServiceImpl implements ClinicService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<Visit> findVisitsByPetId(int petId) {
         return visitRepository.findByPetId(petId);
     }
 
     @Override
-    public Collection<Pet> findPetsByOwnerName(String ownerName) {
-        Collection<Owner> owners = ownerRepository.findByFirstName(ownerName);
+    @Transactional(readOnly = true)
+    public Collection<Pet> findPetsByOwnerName(String ownerName) throws OwnerNotFoundException {
+        Collection<Owner> owners = ownerRepository.findByLastName(ownerName);
+        if (owners.isEmpty()) {
+            throw new OwnerNotFoundException("Owner with last name '" + ownerName + "' not found");
+        }
         Owner owner = new ArrayList<>(owners).get(0);
         return owner.getPets();
     }
@@ -119,5 +125,11 @@ public class ClinicServiceImpl implements ClinicService {
         return vets.stream()
                 .map(vet -> new VetWithSchedule(vet, visitRepository.findScheduleByVetId(vet.getId())))
                 .collect(Collectors.toList());
+    }
+}
+
+class OwnerNotFoundException extends RuntimeException {
+    public OwnerNotFoundException(String message) {
+        super(message);
     }
 }

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
@@ -25,8 +25,9 @@ import org.springframework.samples.petclinic.repository.VisitRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Mostly used as a facade for all Petclinic controllers
@@ -74,13 +75,11 @@ public class ClinicServiceImpl implements ClinicService {
         ownerRepository.save(owner);
     }
 
-
     @Override
     @Transactional
     public void saveVisit(Visit visit) {
         visitRepository.save(visit);
     }
-
 
     @Override
     @Transactional(readOnly = true)
@@ -113,5 +112,12 @@ public class ClinicServiceImpl implements ClinicService {
         return owner.getPets();
     }
 
-
+    @Override
+    @Transactional(readOnly = true)
+    public Collection<VetWithSchedule> findVetsWithSchedules() {
+        List<Vet> vets = vetRepository.findAll();
+        return vets.stream()
+                .map(vet -> new VetWithSchedule(vet, visitRepository.findScheduleByVetId(vet.getId())))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/org/springframework/samples/petclinic/web/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/OwnerController.java
@@ -25,6 +25,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.service.ClinicService;
+import org.springframework.samples.petclinic.service.exceptions.OwnerNotFoundException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -130,7 +131,13 @@ public class OwnerController {
     @GetMapping("/owners/{ownerId}")
     public ModelAndView showOwner(@PathVariable("ownerId") int ownerId) {
         ModelAndView mav = new ModelAndView("owners/ownerDetails");
-        mav.addObject(this.clinicService.findOwnerById(ownerId));
+        try {
+            Owner owner = this.clinicService.findOwnerById(ownerId);
+            mav.addObject(owner);
+        } catch (OwnerNotFoundException ex) {
+            mav = new ModelAndView("error");
+            mav.addObject("message", "Owner not found with id: " + ownerId);
+        }
         return mav;
     }
 
@@ -139,6 +146,13 @@ public class OwnerController {
         Collection<Pet> petsByOwnerName = clinicService.findPetsByOwnerName(name);
         model.put("selections", petsByOwnerName);
         return "pets/petList";
+    }
+
+    @ExceptionHandler(OwnerNotFoundException.class)
+    public ModelAndView handleOwnerNotFoundException(OwnerNotFoundException ex) {
+        ModelAndView mav = new ModelAndView("error");
+        mav.addObject("message", ex.getMessage());
+        return mav;
     }
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/web/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/OwnerController.java
@@ -88,7 +88,7 @@ public class OwnerController {
         }
 
         // find owners by last name
-        Collection<Owner> results = this.clinicService.findOwnerByLastName(owner.getLastName());
+        Collection<Owner> results = this.clinicService.findByLastName(owner.getLastName());
         if (results.isEmpty()) {
             // no owners found
             result.rejectValue("lastName", "notFound", "not found");

--- a/src/main/java/org/springframework/samples/petclinic/web/VetController.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/VetController.java
@@ -17,6 +17,7 @@ package org.springframework.samples.petclinic.web;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.samples.petclinic.model.VetSchedule;
 import org.springframework.samples.petclinic.model.Vets;
 import org.springframework.samples.petclinic.service.ClinicService;
 import org.springframework.stereotype.Controller;
@@ -25,19 +26,21 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.util.List;
 import java.util.Map;
 
 /**
- * @author Juergen Hoeller
- * @author Mark Fisher
- * @author Ken Krebs
- * @author Arjen Poutsma
+ * Copyright (c) 2002-2022 the original author or authors.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Controller class for handling vet-related requests
+ * Authors: Juergen Hoeller, Mark Fisher, Ken Krebs, Arjen Poutsma
  */
 @Controller
 public class VetController {
 
     private final ClinicService clinicService;
-
 
     @Autowired
     public VetController(ClinicService clinicService) {
@@ -46,8 +49,6 @@ public class VetController {
 
     @GetMapping("/vets")
     public String showVetList(Map<String, Object> model) {
-        // Here we are returning an object of type 'Vets' rather than a collection of Vet objects
-        // so it is simpler for Object-Xml mapping
         Vets vets = getVets();
         model.put("vets", vets);
         return "vets/vetList";
@@ -55,29 +56,31 @@ public class VetController {
 
     @GetMapping(value = "/vets.json", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public
-    Vets showJsonVetList() {
+    public Vets showJsonVetList() {
         return getVets();
     }
 
     @GetMapping(value = "/vets.xml", produces = MediaType.APPLICATION_XML_VALUE)
     @ResponseBody
-    public
-    Vets showXmlVetList() {
+    public Vets showXmlVetList() {
         return getVets();
     }
 
     @GetMapping(value = "/vets/pets/visits")
     public String initNewVisitForm(@RequestParam("date") String date, Map<String, Object> model) {
-        throw new IllegalArgumentException();
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @GetMapping("/vets/schedule")
+    public String showVetSchedule(Map<String, Object> model) {
+        List<VetSchedule> vetSchedules = clinicService.findAllVetSchedules();
+        model.put("vetSchedules", vetSchedules);
+        return "vets/vetSchedule";
     }
 
     private Vets getVets() {
-        // Here we are returning an object of type 'Vets' rather than a collection of Vet objects
-        // so it is simpler for JSon/Object mapping
         Vets vets = new Vets();
         vets.getVetList().addAll(this.clinicService.findVets());
         return vets;
     }
-
 }

--- a/src/main/webapp/WEB-INF/jsp/pets/petList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/pets/petList.jsp
@@ -8,6 +8,11 @@
 <petclinic:layout pageName="petList">
     <h2 id="pets">Pets</h2>
 
+    <c:if test="${not empty error}">
+        <div class="alert alert-danger">
+            <c:out value="${error}"/>
+        </div>
+    </c:if>
 
     <c:forEach var="pet" items="${selections}">
         <c:out value="${pet.name} "/>


### PR DESCRIPTION
This pull request addresses the issue where an internal server error 500 was being thrown while creating a new owner, despite the owner's information being successfully saved in the database.

Changes include:
- Updating the `save` method in `JdbcOwnerRepositoryImpl` to properly handle exceptions.
- Ensuring that any exceptions are logged and rethrown as `DataAccessException` to be handled further up in the service layer.

By handling these exceptions properly, we prevent the server from returning an internal error 500 to the client.